### PR TITLE
Apply changes from CSE's current dcc version related to the hack for glib2.27/clang6.0 on 32bit userspace

### DIFF
--- a/dcc
+++ b/dcc
@@ -113,6 +113,50 @@ def compile():
 		# fixme add code to check version supports these
 		sanitizer_args = ['-fsanitize=address', '-fsanitize=undefined', '-fno-sanitize-recover=undefined,integer']
 		which_sanitizer = "address"
+
+	# XXX fix for ASan not working with 32bit binaries using clang 6.0 and glibc 2.27
+	CSE_HACK = True
+	if CSE_HACK and which_sanitizer == "address" and platform.architecture()[0][0:2] == '32':
+		# get the version of clang
+		clang_version = None
+		try:
+			clang_version = subprocess.check_output(["clang", "--version"]).decode("ascii")
+			if debug:
+				print("clang version:", clang_version)
+			m = re.search("clang version ([0-9])+", clang_version)
+			if m is not None:
+				clang_version = int(m.group(1))
+			else:
+				clang_version = None
+		except Exception as e:
+			if debug:
+				print(e)
+
+		# and get the version of glibc
+		libc_version = None
+		try:
+			libc_version = subprocess.check_output(["ldd", "--version"]).decode("ascii")
+			if debug:
+				print("libc version:", libc_version)
+			m = re.search("([0-9]\.[0-9]+)", libc_version)
+			if m is not None:
+				libc_version = float(m.group(1))
+			else:
+				libc_version = None
+		except Exception as e:
+			if debug:
+				print(e)
+
+		if clang_version and libc_version and clang_version <= 6 and libc_version >= 2.27:
+			if debug:
+				print("incompatible clang+libc with ASan, disabling")
+			print("NOTE: ASan is incompatible with this system; as such, " \
+			      "dcc will *not* detect errors such as accessing an invalid array index.", file=sys.stderr)
+			print("[We are working to fix this ASAP]", file=sys.stderr)
+
+			sanitizer_args = []
+
+
 #	if c_compiler == 'clang-3.8' and platform.architecture()[0][0:2] == '32':
 #		# backport clang-3.8 on CSE	 machines needs this
 #		sanitizer_args +=  ['-target', 'i386-pc-linux-gnu']


### PR DESCRIPTION
Not sure whether you're concerned about the repo being up-to-date with what's currently on CSE.

This PR has the patch for the dodgy hack I added to allow dcc to still compile/run when CSE briefly upgraded to glib 2.27 with clang 6.0 where everything exploded.

This patch isn't necessary for older glib versions, or for a 64 bit userspace, and thus hopefully won't be necessary soon, but....