### PR TITLE
Only use prctl(2) on Linux.

### DIFF
--- a/main_wrapper.c
+++ b/main_wrapper.c
@@ -10,7 +10,9 @@
 #include <signal.h>
 #include <limits.h>
 #include <errno.h>
-#include <sys/prctl.h>
+#ifdef __linux__
+# include <sys/prctl.h>
+#endif
 
 static int debug = 0;
 
@@ -233,9 +235,11 @@ static void _explain_error(void) {
 	for (int i = 4; i < 32; i++)
 		close(i);
 
+#ifdef __linux__
     // ensure gdb can ptrace binary
 	// https://www.kernel.org/doc/Documentation/security/Yama.txt
-	prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY);		
+	prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY);
+#endif
 
 #if !__DCC_EMBED_SOURCE__
 	if (debug) fprintf(stderr, "running %s\n", "__DCC_PATH__");


### PR DESCRIPTION
From the man-page: "[prctl(2)] is Linux-specific."  Use the `__linux__` preprocessor symbol to ensure we only try to use it where it exists. There's no reason for dcc to be broken on other platforms (e.g., *BSD) where the rest of the features work fine.