### PR TITLE
Stop DCC from complaining about it's own additions with -Wextra enabled

### DIFF
--- a/dcc_check_output.c
+++ b/dcc_check_output.c
@@ -136,7 +136,7 @@ static unsigned char actual_line[ACTUAL_LINE_MAX + 1];
 // position to put next character in above array
 static int n_actual_line;
 // n bytes seen prior to those in above array
-static size_t n_actual_bytes_seen;
+static ssize_t n_actual_bytes_seen;
 static size_t n_actual_lines_seen;
 
 static unsigned char expected_line[ACTUAL_LINE_MAX + 2];
@@ -150,7 +150,7 @@ static void rstrip_line(unsigned char *line, int last_byte_index);
 static void __dcc_compare_output(unsigned char *actual, size_t size) {
 	int expected_bytes_in_line = get_next_expected_line();
 	debug_printf(2, " __dcc_compare_output() n_actual_lines_seen=%d\n", n_actual_lines_seen);
-	for (int i = 0; i < size; i++) {
+	for (size_t i = 0; i < size; i++) {
 		if (max_stdout_bytes && n_actual_line + n_actual_bytes_seen > max_stdout_bytes) {
 			n_actual_lines_seen++;
 			actual_line[n_actual_line] = '\0';
@@ -310,13 +310,13 @@ static void __dcc_compare_output_error(char *reason, int actual_column, int expe
 	snprintf(buffer[3], sizeof buffer[3], "DCC_N_ACTUAL_BYTES_SEEN=%zu", n_actual_bytes_seen);
 	snprintf(buffer[4], sizeof buffer[4], "DCC_ACTUAL_COLUMN=%d", actual_column);
 	snprintf(buffer[5], sizeof buffer[5], "DCC_EXPECTED_COLUMN=%d", expected_column);
-	for (int i = 0; i < sizeof buffer/sizeof buffer[0]; i++)
+	for (unsigned long int i = 0; i < sizeof buffer/sizeof buffer[0]; i++)
 		putenvd(buffer[i]);
 
 	char line_buffer[2][128 + ACTUAL_LINE_MAX];
 	snprintf(line_buffer[0], sizeof line_buffer[0], "DCC_ACTUAL_LINE=%s", actual_line);
 	snprintf(line_buffer[1], sizeof line_buffer[1], "DCC_EXPECTED_LINE=%s", expected_line);
-	for (int i = 0; i < sizeof line_buffer/sizeof line_buffer[0]; i++)
+	for (unsigned long int i = 0; i < sizeof line_buffer/sizeof line_buffer[0]; i++)
 		putenvd(line_buffer[i]);
 	_explain_error();
 }
@@ -358,4 +358,3 @@ static int getenv_boolean(const char *name, int default_value) {
 	return value ? !strchr("0fFnN", *value) : default_value;
 }
 #endif
-

--- a/dcc_util.c
+++ b/dcc_util.c
@@ -1,5 +1,6 @@
 
 static void launch_valgrind(int argc, char *argv[], char *envp[]) {
+	(void) envp;
 	debug_printf(2, "command=%s\n", "__MONITOR_VALGRIND__");
 #if __N_SANITIZERS__ > 1
 	extern FILE *__real_popen(const char *command, const char *type);
@@ -128,6 +129,7 @@ void __asan_on_error() {
 
 // intercept ASAN explanation
 void _Unwind_Backtrace(void *a, ...) {
+	(void) a;
 	debug_printf(2, "_Unwind_Backtrace\n");
 	_explain_error();
 }
@@ -170,7 +172,7 @@ void __ubsan_on_report(void) {
 	snprintf(buffer[3], sizeof buffer[3], "DCC_UBSAN_ERROR_LINE=%u", OutLine);
 	snprintf(buffer[4], sizeof buffer[4], "DCC_UBSAN_ERROR_COL=%u", OutCol);
 	snprintf(buffer[5], sizeof buffer[5], "DCC_UBSAN_ERROR_MEMORYADDR=%s", OutMemoryAddr);
-	for (int i = 0; i < sizeof buffer/sizeof buffer[0]; i++)
+	for (unsigned long int i = 0; i < sizeof buffer/sizeof buffer[0]; i++)
 		putenv(buffer[i]);
 #endif
 	_explain_error();
@@ -353,7 +355,7 @@ static int debug_printf(int level, const char *format, ...) {
 #include <spawn.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h> 
+#include <unistd.h>
 
 int __real_posix_spawn(pid_t *pid, const char *path,
                        const posix_spawn_file_actions_t *file_actions,


### PR DESCRIPTION
This PR will stop DCC from emitting the following errors about it's own additions with -Wextra enabled
```
<stdin>:869:59: error: unused parameter 'envp' [-Werror,-Wunused-parameter]
static void launch_valgrind(int argc, char *argv[], char *envp[]) {
                                                          ^
<stdin>:1025:30: error: unused parameter 'a' [-Werror,-Wunused-parameter]
void _Unwind_Backtrace(void *a, ...) {
                             ^
<stdin>:1068:20: error: comparison of integers of different signs: 'int' and 'unsigned long' [-Werror,-Wsign-compare]
        for (int i = 0; i < sizeof buffer/sizeof buffer[0]; i++)
                        ~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<stdin>:1435:20: error: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Werror,-Wsign-compare]
        for (int i = 0; i < size; i++) {
                        ~ ^ ~~~~
<stdin>:1436:63: error: comparison of integers of different signs: 'unsigned long' and 'int' [-Werror,-Wsign-compare]
                if (max_stdout_bytes && n_actual_line + n_actual_bytes_seen > max_stdout_bytes) {
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~
<stdin>:1595:20: error: comparison of integers of different signs: 'int' and 'unsigned long' [-Werror,-Wsign-compare]
        for (int i = 0; i < sizeof buffer/sizeof buffer[0]; i++)
                        ~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<stdin>:1601:20: error: comparison of integers of different signs: 'int' and 'unsigned long' [-Werror,-Wsign-compare]
        for (int i = 0; i < sizeof line_buffer/sizeof line_buffer[0]; i++)
                        ~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

DCC will still produce the following errors about it's own additions with -Weverything enabled
```
<stdin>:35:9: error: macro name is a reserved identifier [-Werror,-Wreserved-id-macro]
#define _GNU_SOURCE
        ^
<stdin>:258:8: error: padding size of 'struct cookie' with 4 bytes to alignment boundary [-Werror,-Wpadded]
struct cookie {
       ^
<stdin>:580:24: error: implicit conversion changes signedness: 'ssize_t' (aka 'long') to 'size_t' (aka 'unsigned long') [-Werror,-Wsign-conversion]
        size_t n_bytes_read = read(cookie->fd, buf, size);
               ~~~~~~~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
<stdin>:602:9: error: implicit conversion changes signedness: 'size_t' (aka 'unsigned long') to 'ssize_t' (aka 'long') [-Werror,-Wsign-conversion]
        return n_bytes_read;
        ~~~~~~ ^~~~~~~~~~~~
<stdin>:614:27: error: implicit conversion changes signedness: 'ssize_t' (aka 'long') to 'size_t' (aka 'unsigned long') [-Werror,-Wsign-conversion]
        size_t n_bytes_written = write(cookie->fd, buf, size);
               ~~~~~~~~~~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
<stdin>:623:9: error: implicit conversion changes signedness: 'size_t' (aka 'unsigned long') to 'ssize_t' (aka 'long') [-Werror,-Wsign-conversion]
        return n_bytes_written;
        ~~~~~~ ^~~~~~~~~~~~~~~
<stdin>:645:9: error: implicit conversion loses integer precision: 'off_t' (aka 'long') to 'int' [-Werror,-Wshorten-64-to-32]
        return result;
        ~~~~~~ ^~~~~~
<stdin>:895:21: error: variable length array used [-Werror,-Wvla]
        char *valgrind_argv[valgrind_command_len + argc + 1];
                           ^
<stdin>:940:33: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
static void disable_check_output();
                                ^
                                 void
<stdin>:941:29: error: function '__dcc_error_exit' could be declared with attribute 'noreturn' [-Werror,-Wmissing-noreturn]
void __dcc_error_exit(void) {
                            ^
<stdin>:964:21: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void __asan_on_error() NO_SANITIZE;
                    ^
                     void
<stdin>:971:44: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
        extern char *__asan_get_report_description();
                                                  ^
                                                   void
<stdin>:972:34: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
        extern int __asan_report_present();
                                        ^
                                         void
<stdin>:966:6: error: no previous prototype for function '__asan_on_error' [-Werror,-Wmissing-prototypes]
void __asan_on_error() {
     ^
<stdin>:964:6: note: this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function
void __asan_on_error() NO_SANITIZE;
     ^
                     void
<stdin>:986:6: error: no previous prototype for function '_Unwind_Backtrace' [-Werror,-Wmissing-prototypes]
void _Unwind_Backtrace(void *a, ...) {
     ^
<stdin>:964:6: note: this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function
void __asan_on_error() NO_SANITIZE;
     ^
                     void
<stdin>:986:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
void _Unwind_Backtrace(void *a, ...) {
^
static 
<stdin>:993:7: error: no previous prototype for function '__asan_default_options' [-Werror,-Wmissing-prototypes]
char *__asan_default_options() {
      ^
<stdin>:964:6: note: this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function
void __asan_on_error() NO_SANITIZE;
     ^
                     void
<stdin>:986:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
void _Unwind_Backtrace(void *a, ...) {
^
static 
<stdin>:993:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
char *__asan_default_options() {
^
static 
<stdin>:1008:6: error: no previous prototype for function '__ubsan_on_report' [-Werror,-Wmissing-prototypes]
void __ubsan_on_report(void) {
     ^
<stdin>:964:6: note: this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function
void __asan_on_error() NO_SANITIZE;
     ^
                     void
<stdin>:986:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
void _Unwind_Backtrace(void *a, ...) {
^
static 
<stdin>:993:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
char *__asan_default_options() {
^
static 
<stdin>:1008:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
void __ubsan_on_report(void) {
^
static 
<stdin>:1038:7: error: no previous prototype for function '__ubsan_default_options' [-Werror,-Wmissing-prototypes]
char *__ubsan_default_options() {
      ^
<stdin>:964:6: note: this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function
void __asan_on_error() NO_SANITIZE;
     ^
                     void
<stdin>:986:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
void _Unwind_Backtrace(void *a, ...) {
^
static 
<stdin>:993:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
char *__asan_default_options() {
^
static 
<stdin>:1008:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
void __ubsan_on_report(void) {
^
static 
<stdin>:1038:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
char *__ubsan_default_options() {
^
static 
format, arg);
<stdin>:1200:60: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
    int n = vfprintf(debug_stream ? debug_stream : stderr, format, arg);
                                                           ^~~~~~
fatal error: too many errors emitted, stopping now [-ferror-limit=]
<stdin>:964:6: note: this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function
void __asan_on_error() NO_SANITIZE;
     ^
                     void
<stdin>:986:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
void _Unwind_Backtrace(void *a, ...) {
^
static 
<stdin>:993:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
char *__asan_default_options() {
^
static 
<stdin>:1008:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
void __ubsan_on_report(void) {
^
static 
<stdin>:1038:1: note: declare 'static' if the function is not intended to be used outside of this translation unit
char *__ubsan_default_options() {
^
static 
```