### PR TITLE
report reachable memory as memory leaks

### DIFF
--- a/tests/expected_output/leak_then_exit--leak-check/000000-clang-13.0-x86_64-pc-linux-gnu.txt
+++ b/tests/expected_output/leak_then_exit--leak-check/000000-clang-13.0-x86_64-pc-linux-gnu.txt
@@ -1,0 +1,2 @@
+
+Error: free not called for memory allocated with malloc in function main in leak_then_exit.c at line 6.

--- a/tests/run_time_errors/leak_then_exit.c
+++ b/tests/run_time_errors/leak_then_exit.c
@@ -1,0 +1,8 @@
+//dcc_flags=--leak-check
+
+#include <stdlib.h>
+
+int main(void) {
+	char *p = malloc(1);
+	exit(!p);
+}

--- a/wrapper_c/dcc_util.c
+++ b/wrapper_c/dcc_util.c
@@ -27,12 +27,13 @@ static void launch_valgrind(int argc, char *argv[]) {
 		"-q",
 		"--vgdb=yes",
 		"--leak-check=__LEAK_CHECK_YES_NO__",
+		"--show-leak-kinds=all",
 		"--suppressions=__SUPRESSIONS_FILE__",
 		"--max-stackframe=16000000",
 		"--partial-loads-ok=no",
 		"--malloc-fill=0xbe",
 		"--free-fill=0xbe",
-		 "--vgdb-error=1"
+		"--vgdb-error=1"
 	};
 
 	int valgrind_command_len = sizeof valgrind_command / sizeof valgrind_command[0];


### PR DESCRIPTION
The following program has a memory leak but isn't reported by `dcc --leak-check` or `dcc --leak-check --valgrind`:
```c
#include <stdlib.h>

int main(int argc, char **argv) {
	void *p = malloc(1);
	exit(!p);
}
```
This is because valgrind reports the memory as still being reachable, I think because it's still on the stack frame after `exit(0)`, unlike when `main` does `return 0`.

One fix (which this PR implements) is to just report reachable memory (as well as indirectly lost memory) as being a memory leak. Based on some limited testing this doesn't seem to create any false positives, although I'm not certain that there aren't any unintended consequences to this.