### PR TITLE
Fix dcc leak-check regression

### DIFF
--- a/compile_time_python/compile.py
+++ b/compile_time_python/compile.py
@@ -13,9 +13,10 @@ FILES_EMBEDDED_IN_BINARY = [
     "util.py",
 ]
 
-# its possible  -g -fno-omit-frame-pointer could be needed here
+# its possible -fno-omit-frame-pointer could be needed here
 WRAPPER_SOURCE_COMPILER_ARGS = """
     -O3
+    -g
 """.split()
 
 DEBUG_COMPILE_FILE = "tmp_dcc.sh"


### PR DESCRIPTION
Regressed in https://github.com/COMP1511UNSW/dcc/commit/ea445a0

There may still be more work required, since it seems the leak message is not being intercepted and rewritten... however, this is probably still an improvement on the current situation.

```
$ git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean

$ cat test1.c
int main(void) {}

$ cat test2.c
#include <stdlib.h>

int main(void) {
        int *p = malloc(sizeof(*p));
}

$ cat test3.c
#include <stdlib.h>

int main(void) {
        int *p = malloc(sizeof(*p));
        free(p);
}

$ make

...

$ ./dcc --leak-check test1.c; ./a.out

Error: free not called for memory allocated with malloc in function fopencookie@@GLIBC_2.2.5 in iofopncook.c at line 205.

$ ./dcc --leak-check test2.c; ./a.out

Error: free not called for memory allocated with malloc in function main in test2.c at line 4.

=================================================================
==45152==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x7f8fffecd7ee in __interceptor_malloc (/usr/lib/clang/14.0.0/lib/linux/libclang_rt.asan-x86_64.so+0xcd7ee) (BuildId: 0fc20d2022c0d572c45850b6d559d9ccfabd5443)
    #1 0x557072aa0a11 in main /tmp/tmp.PYjAlLvwiX/dcc/test2.c:4:11
    #2 0x557072a9dc9c in __wrap_main (/tmp/tmp.PYjAlLvwiX/dcc/a.out+0x3c9c) (BuildId: 96454792f94abaa64248b9c8fa996f6557fd4317)

SUMMARY: AddressSanitizer: 4 byte(s) leaked in 1 allocation(s).

$ ./dcc --leak-check test3.c; ./a.out

Error: free not called for memory allocated with malloc in function fopencookie@@GLIBC_2.2.5 in iofopncook.c at line 205.

$ sed -i '19i -g' compile_time_python/compile.py

$ make

...

$ ./dcc --leak-check test1.c; ./a.out

$ ./dcc --leak-check test2.c; ./a.out

=================================================================
==45610==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x7f016d8cd7ee in __interceptor_malloc (/usr/lib/clang/14.0.0/lib/linux/libclang_rt.asan-x86_64.so+0xcd7ee) (BuildId: 0fc20d2022c0d572c45850b6d559d9ccfabd5443)
    #1 0x55b3094e0a11 in main /tmp/tmp.PYjAlLvwiX/dcc/test2.c:4:11
    #2 0x55b3094ddc9c in __dcc_main_sanitizer1 /tmp/tmp.PYjAlLvwiX/dcc/<stdin>:204:7
    #3 0x55b3094ddc9c in __wrap_main /tmp/tmp.PYjAlLvwiX/dcc/<stdin>:193:3

SUMMARY: AddressSanitizer: 4 byte(s) leaked in 1 allocation(s).

$ ./dcc --leak-check test3.c; ./a.out

$ git diff | cat
diff --git a/compile_time_python/compile.py b/compile_time_python/compile.py
index 5ccdc84..23e8361 100644
--- a/compile_time_python/compile.py
+++ b/compile_time_python/compile.py
@@ -16,6 +16,7 @@ FILES_EMBEDDED_IN_BINARY = [
 # its possible  -g -fno-omit-frame-pointer could be needed here
 WRAPPER_SOURCE_COMPILER_ARGS = """
     -O3
+-g
 """.split()
 
 DEBUG_COMPILE_FILE = "tmp_dcc.sh"
```