### PR TITLE
Modify readme to always link to the latest binary download

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ int main(void) {
 
 	```bash
 	sudo apt install  clang gcc gdb valgrind python3 curl
-	sudo curl -L https://github.com/COMP1511UNSW/dcc/releases/download/2.22/dcc -o /usr/local/bin/dcc
+	sudo curl -L https://github.com/COMP1511UNSW/dcc/releases/latest/download/dcc -o /usr/local/bin/dcc
 	sudo chmod o+rx  /usr/local/bin/dcc
 	```
 
@@ -270,7 +270,7 @@ int main(void) {
 
 	```bash
 	sudo pacman -S clang gcc gdb valgrind python3 curl
-	sudo curl -L https://github.com/COMP1511UNSW/dcc/releases/download/2.22/dcc -o /usr/local/bin/dcc
+	sudo curl -L https://github.com/COMP1511UNSW/dcc/releases/latest/download/dcc -o /usr/local/bin/dcc
 	sudo chmod o+rx  /usr/local/bin/dcc
 	```
 
@@ -278,7 +278,7 @@ int main(void) {
 
 	```bash
 	sudo yum install clang gcc gdb valgrind python3 curl
-	sudo curl -L https://github.com/COMP1511UNSW/dcc/releases/download/2.22/dcc -o /usr/local/bin/dcc
+	sudo curl -L https://github.com/COMP1511UNSW/dcc/releases/latest/download/dcc -o /usr/local/bin/dcc
 	sudo chmod o+rx  /usr/local/bin/dcc
 	```
 
@@ -286,7 +286,7 @@ int main(void) {
 
 	```bash
 	sudo zypper install clang gcc gdb valgrind python3 curl
-	sudo curl -L https://github.com/COMP1511UNSW/dcc/releases/download/2.22/dcc -o /usr/local/bin/dcc
+	sudo curl -L https://github.com/COMP1511UNSW/dcc/releases/latest/download/dcc -o /usr/local/bin/dcc
 	sudo chmod o+rx  /usr/local/bin/dcc
 	```
 	
@@ -301,7 +301,7 @@ int main(void) {
 	Note: It is usually not a good idea to blindly run remote bash scripts in your terminal, you can inspect the file by opening the URL and reading to see what it does yourself.
 
     ```bash
-	sudo curl -L https://github.com/COMP1511UNSW/dcc/releases/download/2.22/dcc -o /usr/local/bin/dcc
+	sudo curl -L https://github.com/COMP1511UNSW/dcc/releases/latest/download/dcc -o /usr/local/bin/dcc
 	sudo chmod o+rx  /usr/local/bin/dcc
     ```
 	


### PR DESCRIPTION
Currently, `README.md`'s installation instructions link to a specific release, meaning that it needs to be updated in many places before each release.

This PR updates these links to point to the latest binary (https://github.com/COMP1511UNSW/dcc/releases/latest/download/dcc) which will hopefully save some effort in the future.

The `.deb` download contains the version information in the filename, so unfortunately I can't make the link to that be static, but if that filename is changed to something like `dcc_all.deb`, a similar thing could be done for that.

Hope this is helpful!