### PR TITLE
Fix unescaped backslash causing warning in Python 3.12

### DIFF
--- a/compile_time_python/compiler_explanations.py
+++ b/compile_time_python/compiler_explanations.py
@@ -1027,7 +1027,7 @@ if you want an actual backslash in your string use **{BACKSLASH * 2}**
 """,
         reproduce="""\
 int main(void) {
-   return (int)"\_/";
+   return (int)"\\_/";
 }
 """,
     ),


### PR DESCRIPTION
Running `dcc` with Python 3.12 produces this warning:
```
/path/to/dcc/compiler_explanations.py:1028: SyntaxWarning: invalid escape sequence '\_'
/path/to/dcc/compiler_explanations.py:1028: SyntaxWarning: invalid escape sequence '\_'
```
due to an unescaped backslash in `compiler_explanations.py`. Originally this was just causing a `DeprecationWarning` (which was not emitted) but now in Python 3.12 it causes a `SyntaxWarning` every time `dcc` runs (and in a future Python versions will cause a `SyntaxError`). Escaping the backslash fixes the problem (and doesn't alter the value of the string).