### PR TITLE
Attribute errors in threads to the correct thread

### DIFF
--- a/run_time_python/explain_error.py
+++ b/run_time_python/explain_error.py
@@ -11,6 +11,14 @@ def explain_error(output_stream, color):
     # file descriptor 3 is a dup of stderr (see below)
     # stdout & stderr have been diverted to /dev/null
     print(file=output_stream)
+
+    dprint(2, os.environ.get("DCC_ASAN_THREAD"))
+    if "DCC_ASAN_THREAD" in os.environ:
+        # gdb's thread numbers start counting at 1
+        # asan's thread numbers start counting at 0
+        thread_id = int(os.environ.get("DCC_ASAN_THREAD")) + 1
+        gdb_interface.gdb_execute(f"thread {thread_id}")
+
     stack = parse_stack()
     location = stack[0] if stack else None
     signal_number = int(os.environ.get("DCC_SIGNAL", signal.SIGABRT))

--- a/run_time_python/explain_error.py
+++ b/run_time_python/explain_error.py
@@ -18,6 +18,14 @@ def explain_error(output_stream, color):
         # asan's thread numbers start counting at 0
         thread_id = int(os.environ.get("DCC_ASAN_THREAD")) + 1
         gdb_interface.gdb_execute(f"thread {thread_id}")
+    elif "DCC_SIGNAL_THREAD" in os.environ:
+        # signal gives us the Linux TID, gdb calls this the LWP
+        threads = gdb_interface.gdb_execute("info threads").split('\n')
+        lwp = int(os.environ.get("DCC_SIGNAL_THREAD"))
+        # should only be one thread
+        thread_entry = [line for line in threads if f"(LWP {lwp})" in line][0]
+        thread_id = int(thread_entry[2:].split(' ')[0])
+        gdb_interface.gdb_execute(f"thread {thread_id}")
 
     stack = parse_stack()
     location = stack[0] if stack else None

--- a/wrapper_c/dcc_util.c
+++ b/wrapper_c/dcc_util.c
@@ -247,6 +247,10 @@ static void __dcc_signal_handler(int signum) {
     putenvd(
         signum_buffer); // less likely? to trigger another error than direct setenv
 
+    char threadid_buffer[64];
+    snprintf(threadid_buffer, sizeof threadid_buffer, "DCC_SIGNAL_THREAD=%ld", (long)gettid());
+    putenvd(threadid_buffer);
+
     _explain_error(); // not reached
 }
 

--- a/wrapper_c/dcc_util.c
+++ b/wrapper_c/dcc_util.c
@@ -119,8 +119,17 @@ void __asan_on_error(void) {
 #if __SANITIZER__ == ADDRESS && __CLANG_VERSION_MAJOR__ >= 6
     extern char *__asan_get_report_description();
     extern int __asan_report_present();
+    extern void *__asan_get_report_address();
+    extern size_t __asan_get_alloc_stack(void *, void **, size_t, int *);
+    // putenv does not copy strings, we need to alloc it outside the if block scope
+    char thread_env[64];
     if (__asan_report_present()) {
         report = __asan_get_report_description();
+
+        int thread_id;
+        __asan_get_alloc_stack(__asan_get_report_address(), NULL, 0, &thread_id);
+        snprintf(thread_env, sizeof thread_env, "DCC_ASAN_THREAD=%d", thread_id);
+        putenvd(thread_env);
     }
 #endif
     char report_description[8192];


### PR DESCRIPTION
This trivial program:
```
#include <stdio.h>
#include <stdlib.h>
#include <pthread.h>

void *thread(void *data) {
	char *s = malloc(8 * sizeof(char));
	s[10] = 0;
	free(s);
	return 0;
}

int main(void) {
	pthread_t thread_data;
	pthread_create(&thread_data, NULL, thread, NULL);
	pthread_join(thread_data, NULL);
}
```

Previously outputted

```
=================================================================

Runtime error: malloc buffer overflow
dcc explanation: access past the end of malloc'ed memory.
  Make sure you have allocated enough memory for the size of your struct/array.
  A common error is to use the size of a pointer instead of the size of the struct or array.

  For more information see: https://comp1511unsw.github.io/dcc/malloc_sizeof.html

Execution stopped in main() in a.c at line 15:

int main(void) {
	pthread_t thread_data;
	pthread_create(&thread_data, NULL, thread, NULL);
-->	pthread_join(thread_data, NULL);
}

Values when execution stopped:

thread_data = 127271036778176

```

Which is clearly incorrect, as the error occurs within the thread.
This set of changes makes DCC correctly trace the error back to the originating thread, for ASAN and signal errors.

Motivation: I found this very very confusing the first few times I ran across this bug in COMP1521 this term, so I fixed it :smile: 