### PR TITLE
Packaging: add a NixOS Flake to support installation using the Nix package manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ debian
 # don't accidentally add random test files to repo
 /*.c
 /*.sh
+
+# Nix build outputs
+result

--- a/README.md
+++ b/README.md
@@ -289,11 +289,17 @@ int main(void) {
 	sudo curl -L https://github.com/COMP1511UNSW/dcc/releases/latest/download/dcc -o /usr/local/bin/dcc
 	sudo chmod o+rx  /usr/local/bin/dcc
 	```
-	
-	
+
+* NixOS, and systems using the Nix package manager:
+  
+  Permanent installation to `configuration.nix`: 
+  `(builtins.getFlake "github:COMP1511UNSW/dcc?ref=master").packages.x86_64-linux.default`
+  
+  `dcc` inside a development shell:   `nix develop "github:COMP1511UNSW/dcc?ref=master"`
+
 * MacOS
-	Install python3 - see https://docs.python-guide.org/starting/install3/osx/
-	Install gdb - see https://sourceware.org/gdb/wiki/PermissionsDarwin
+	Install `python3` - see https://docs.python-guide.org/starting/install3/osx/
+	Install `gdb` - see https://sourceware.org/gdb/wiki/PermissionsDarwin
 	In your terminal, run:
 	```bash
 	bash <(curl -s https://raw.githubusercontent.com/COMP1511UNSW/dcc/master/install_scripts/macos_install.sh)
@@ -464,4 +470,3 @@ Code for ANSI colors in colors.py is by Giorgos Verigakis
 # License
 
 GPLv3
-

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1763421233,
+        "narHash": "sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "89c2b2330e733d6cdb5eae7b899326930c2c0648",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763421233,
-        "narHash": "sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw=",
+        "lastModified": 1763622513,
+        "narHash": "sha256-1jQnuyu82FpiSxowrF/iFK6Toh9BYprfDqfs4BB+19M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "89c2b2330e733d6cdb5eae7b899326930c2c0648",
+        "rev": "c58bc7f5459328e4afac201c5c4feb7c818d604b",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -74,8 +74,6 @@
                   }"
               '';
             };
-          # gdb required as a runtime dependency for all programs built with dcc
-          gdb = pkgs.gdb;
         }
       );
 
@@ -85,6 +83,10 @@
           default = pkgs.mkShell {
             packages = [
               self.packages.${system}.default
+              # gdb and valgrind are required as a runtime dependencies for all
+              # programs built with dcc. We need to bring them into the user's
+              # PATH or they'll be unable to run apps built with `dcc` (unless
+              # they install them manually).
               pkgs.gdb
               pkgs.valgrind
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
                 cp ${binName} $out/bin/${binName}
                 # Also copy across gdb so that it is avaiable after installation
                 cp "$(which gdb)" $out/bin/gdb
+                cp "$(which valgrind)" $out/bin/valgrind
                 wrapProgram $out/bin/dcc \
                   --prefix PATH : "${pkgs.lib.makeBinPath [ pkgs.gcc pkgs.clang pkgs.python3 pkgs.gdb pkgs.valgrind ]}"
               '';

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "DCC - The Debugging C/C++ Compiler";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
   };
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
         { pkgs }:
         {
           # dcc
-          default =
+          dcc =
             let
               binName = "dcc";
               cDependencies = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
                 gnumake
                 git
                 zip
+                which
               ];
             in
             pkgs.stdenv.mkDerivation {
@@ -54,7 +55,9 @@
               buildPhase = "make";
               installPhase = ''
                 mkdir -p $out/bin
-                cp ${binName} $out/bin/
+                cp ${binName} $out/bin/${binName}
+                # Also copy across gdb so that it is avaiable after installation
+                cp "$(which gdb)" $out/bin/gdb
               '';
             };
           # gdb required as a runtime dependency for all programs built with dcc

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,16 @@
                 cp "$(which gdb)" $out/bin/gdb
                 cp "$(which valgrind)" $out/bin/valgrind
                 wrapProgram $out/bin/dcc \
-                  --prefix PATH : "${pkgs.lib.makeBinPath [ pkgs.gcc pkgs.clang pkgs.python3 pkgs.gdb pkgs.valgrind ]}"
+                  --inherit-argv0 \
+                  --prefix PATH : "${
+                    pkgs.lib.makeBinPath [
+                      pkgs.gcc
+                      pkgs.clang
+                      pkgs.python3
+                      pkgs.gdb
+                      pkgs.valgrind
+                    ]
+                  }"
               '';
             };
           # gdb required as a runtime dependency for all programs built with dcc

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,10 @@
                 cp ${binName} $out/bin/${binName}
                 ln -s $out/bin/${binName} $out/bin/d++
                 ln -s $out/bin/${binName} $out/bin/dcc++
-                # Also copy across gdb so that it is avaiable after installation
+                # gdb and valgrind are required as a runtime dependencies for
+                # all programs built with dcc. We need to bring them into the
+                # user's PATH or they'll be unable to run apps built with `dcc`
+                # (unless they install them manually).
                 cp "$(which gdb)" $out/bin/gdb
                 cp "$(which valgrind)" $out/bin/valgrind
                 wrapProgram $out/bin/dcc \
@@ -81,15 +84,7 @@
         { system, pkgs }:
         {
           default = pkgs.mkShell {
-            packages = [
-              self.packages.${system}.default
-              # gdb and valgrind are required as a runtime dependencies for all
-              # programs built with dcc. We need to bring them into the user's
-              # PATH or they'll be unable to run apps built with `dcc` (unless
-              # they install them manually).
-              pkgs.gdb
-              pkgs.valgrind
-            ];
+            packages = [ self.packages.${system}.default ];
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -51,13 +51,15 @@
               name = binName;
               src = self;
               buildInputs = cDependencies;
-              # nativeBuildInputs = [ pkgs.makeWrapper ];
+              nativeBuildInputs = [ pkgs.makeWrapper ];
               buildPhase = "make";
               installPhase = ''
                 mkdir -p $out/bin
                 cp ${binName} $out/bin/${binName}
                 # Also copy across gdb so that it is avaiable after installation
                 cp "$(which gdb)" $out/bin/gdb
+                wrapProgram $out/bin/dcc \
+                  --prefix PATH : "${pkgs.lib.makeBinPath [ pkgs.gcc pkgs.clang pkgs.python3 pkgs.gdb pkgs.valgrind ]}"
               '';
             };
           # gdb required as a runtime dependency for all programs built with dcc

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
       packages = forAllSystems (
         { pkgs }:
         {
+          # dcc
           default =
             let
               binName = "dcc";
@@ -48,15 +49,15 @@
               name = binName;
               src = self;
               buildInputs = cDependencies;
-              nativeBuildInputs = [ pkgs.makeWrapper ];
+              # nativeBuildInputs = [ pkgs.makeWrapper ];
               buildPhase = "make";
               installPhase = ''
                 mkdir -p $out/bin
                 cp ${binName} $out/bin/
-                wrapProgram $out/bin/dcc \
-                --prefix PATH : "${pkgs.lib.makeBinPath [ pkgs.gcc pkgs.clang pkgs.python3 pkgs.gdb pkgs.valgrind ]}"
               '';
             };
+          # gdb required as a runtime dependency for all programs built with dcc
+          gdb = pkgs.gdb;
         }
       );
     };

--- a/flake.nix
+++ b/flake.nix
@@ -22,16 +22,17 @@
         nixpkgs.lib.genAttrs allSystems (
           system:
           f {
+            system = system;
             pkgs = import nixpkgs { inherit system; };
           }
         );
     in
     {
       packages = forAllSystems (
-        { pkgs }:
+        { pkgs, ... }:
         {
           # dcc
-          dcc =
+          default =
             let
               binName = "dcc";
               cDependencies = with pkgs; [
@@ -58,6 +59,18 @@
             };
           # gdb required as a runtime dependency for all programs built with dcc
           gdb = pkgs.gdb;
+        }
+      );
+
+      devShells = forAllSystems (
+        { system, pkgs }:
+        {
+          default = pkgs.mkShell {
+            packages = [
+              self.packages.${system}.default
+              pkgs.gdb
+            ];
+          };
         }
       );
     };

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,8 @@
               installPhase = ''
                 mkdir -p $out/bin
                 cp ${binName} $out/bin/${binName}
+                ln -s $out/bin/${binName} $out/bin/d++
+                ln -s $out/bin/${binName} $out/bin/dcc++
                 # Also copy across gdb so that it is avaiable after installation
                 cp "$(which gdb)" $out/bin/gdb
                 cp "$(which valgrind)" $out/bin/valgrind

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
             packages = [
               self.packages.${system}.default
               pkgs.gdb
+              pkgs.valgrind
             ];
           };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
             let
               binName = "dcc";
               cDependencies = with pkgs; [
+                gcc
                 clang
                 python3
                 gdb
@@ -44,13 +45,16 @@
               ];
             in
             pkgs.stdenv.mkDerivation {
-              name = "dcc";
+              name = binName;
               src = self;
               buildInputs = cDependencies;
+              nativeBuildInputs = [ pkgs.makeWrapper ];
               buildPhase = "make";
               installPhase = ''
                 mkdir -p $out/bin
                 cp ${binName} $out/bin/
+                wrapProgram $out/bin/dcc \
+                --prefix PATH : "${pkgs.lib.makeBinPath [ pkgs.gcc pkgs.clang pkgs.python3 pkgs.gdb pkgs.valgrind ]}"
               '';
             };
         }


### PR DESCRIPTION
Nix is a declarative package management system. This PR adds a Nix Flake so that NixOS users can easily add `dcc` to their systems.

Notably, this Flake:

* Builds `dcc` from source
* Provides an isolated installation, to ensure `dcc`'s dependencies don't interfere with the rest of the system
* Exposes compiled application runtime dependencies `gdb` and `valgrind` to the user's path so they can run executables compiled with `dcc`.

I also documented this in the `README.md`

Currently known issues:
* the program is reported as `/nix/store/89f4fpnmv2794yw7xdp0fhd2wjb5jb2i-dcc/bin/.dcc-wrapped` in the usage info, even though the wrapper option `--inherit-argv0` is given. I believe this has something to do with the way Nix modifies the built `dcc` binary to point it to an isolated `python3`, but I am really not sure what's up with this.